### PR TITLE
Add Nix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ OPTIONS:
 yay -S gh-cal-bin
 ```
 
+> Nix (nixpkgs unstable)
+
+```sh
+nix-env -iA nixpkgs.gh-cal
+```
+
 # Build
 
 > You must have cargo installed.


### PR DESCRIPTION
`gh-cal` [is now](https://github.com/NixOS/nixpkgs/pull/172187) packaged in the Nix package collections and can be installed from [`nixpkgs-unstable`](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=gh-cal).